### PR TITLE
Add service config support

### DIFF
--- a/src/prompt_passage/cli.py
+++ b/src/prompt_passage/cli.py
@@ -1,6 +1,15 @@
 import uvicorn
+
 from .proxy_app import app
+from .config import load_config, default_config_path, ServiceCfg
 
 
 def main() -> None:
-    uvicorn.run(app, host="0.0.0.0", port=8095)
+    config_path = default_config_path()
+    try:
+        cfg = load_config(config_path)
+    except Exception:
+        cfg = None
+
+    port = cfg.service.port if cfg and cfg.service else ServiceCfg().port
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/src/prompt_passage/proxy_app.py
+++ b/src/prompt_passage/proxy_app.py
@@ -8,10 +8,9 @@ from uvicorn.logging import DefaultFormatter
 from fastapi import FastAPI, Request, Response, status
 from fastapi.responses import StreamingResponse
 from starlette.background import BackgroundTask
-from pathlib import Path
 import json
 
-from .config import load_config, ProviderCfg
+from .config import load_config, ProviderCfg, default_config_path
 from .forwarder import Forwarder
 
 _handler = logging.StreamHandler()
@@ -43,7 +42,7 @@ _forwarder: Forwarder | None = None
 async def _startup() -> None:
     global _provider_map, _forwarder  # noqa: PLW0603
 
-    config_path = Path.home() / ".prompt_passage" / "config.yaml"
+    config_path = default_config_path()
     _provider_map = load_config(config_path).providers
     _forwarder = Forwarder(_provider_map)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,9 +24,7 @@ class GeneratorStream(httpx.AsyncByteStream):
 
 @pytest.fixture()
 def create_config(tmp_path: Path) -> Path:
-    cfg_dir = tmp_path / ".prompt_passage"
-    cfg_dir.mkdir()
-    cfg_file = cfg_dir / "config.yaml"
+    cfg_file = tmp_path / ".prompt-passage.yaml"
     cfg_data = {
         "providers": {
             "test-model": {
@@ -45,9 +43,7 @@ def create_config(tmp_path: Path) -> Path:
 
 @pytest.fixture()
 def create_config_azcli(tmp_path: Path) -> Path:
-    cfg_dir = tmp_path / ".prompt_passage"
-    cfg_dir.mkdir()
-    cfg_file = cfg_dir / "config.yaml"
+    cfg_file = tmp_path / ".prompt-passage.yaml"
     cfg_data = {
         "providers": {
             "test-model": {
@@ -62,7 +58,7 @@ def create_config_azcli(tmp_path: Path) -> Path:
 
 
 def test_chat_proxy_success(monkeypatch: pytest.MonkeyPatch, create_config: Path, httpx_mock: HTTPXMock) -> None:
-    monkeypatch.setenv("HOME", str(create_config.parent.parent))
+    monkeypatch.setenv("HOME", str(create_config.parent))
     monkeypatch.setenv("TEST_API_KEY_ENV", "secret-token")
 
     proxy_app = importlib.import_module("prompt_passage.proxy_app")
@@ -82,7 +78,7 @@ def test_chat_proxy_success(monkeypatch: pytest.MonkeyPatch, create_config: Path
 
 
 def test_chat_proxy_upstream_error(monkeypatch: pytest.MonkeyPatch, create_config: Path, httpx_mock: HTTPXMock) -> None:
-    monkeypatch.setenv("HOME", str(create_config.parent.parent))
+    monkeypatch.setenv("HOME", str(create_config.parent))
     monkeypatch.setenv("TEST_API_KEY_ENV", "token")
 
     proxy_app = importlib.import_module("prompt_passage.proxy_app")
@@ -101,7 +97,7 @@ def test_chat_proxy_upstream_error(monkeypatch: pytest.MonkeyPatch, create_confi
 
 
 def test_chat_proxy_azcli(monkeypatch: pytest.MonkeyPatch, create_config_azcli: Path, httpx_mock: HTTPXMock) -> None:
-    monkeypatch.setenv("HOME", str(create_config_azcli.parent.parent))
+    monkeypatch.setenv("HOME", str(create_config_azcli.parent))
 
     token_obj = type("Tok", (), {"token": "cli-token"})()
 
@@ -127,7 +123,7 @@ def test_chat_proxy_azcli(monkeypatch: pytest.MonkeyPatch, create_config_azcli: 
 
 
 def test_chat_proxy_stream(monkeypatch: pytest.MonkeyPatch, create_config: Path, httpx_mock: HTTPXMock) -> None:
-    monkeypatch.setenv("HOME", str(create_config.parent.parent))
+    monkeypatch.setenv("HOME", str(create_config.parent))
     monkeypatch.setenv("TEST_API_KEY_ENV", "tok")
 
     proxy_app = importlib.import_module("prompt_passage.proxy_app")
@@ -155,7 +151,7 @@ def test_chat_proxy_stream(monkeypatch: pytest.MonkeyPatch, create_config: Path,
 
 
 def test_chat_proxy_unknown_provider(monkeypatch: pytest.MonkeyPatch, create_config: Path) -> None:
-    monkeypatch.setenv("HOME", str(create_config.parent.parent))
+    monkeypatch.setenv("HOME", str(create_config.parent))
     monkeypatch.setenv("TEST_API_KEY_ENV", "tok")
 
     proxy_app = importlib.import_module("prompt_passage.proxy_app")
@@ -170,7 +166,7 @@ def test_chat_proxy_unknown_provider(monkeypatch: pytest.MonkeyPatch, create_con
 
 
 def test_chat_proxy_upstream_500(monkeypatch: pytest.MonkeyPatch, create_config: Path, httpx_mock: HTTPXMock) -> None:
-    monkeypatch.setenv("HOME", str(create_config.parent.parent))
+    monkeypatch.setenv("HOME", str(create_config.parent))
     monkeypatch.setenv("TEST_API_KEY_ENV", "tok")
 
     proxy_app = importlib.import_module("prompt_passage.proxy_app")
@@ -189,7 +185,7 @@ def test_chat_proxy_upstream_500(monkeypatch: pytest.MonkeyPatch, create_config:
 def test_chat_proxy_stream_upstream_error(
     monkeypatch: pytest.MonkeyPatch, create_config: Path, httpx_mock: HTTPXMock
 ) -> None:
-    monkeypatch.setenv("HOME", str(create_config.parent.parent))
+    monkeypatch.setenv("HOME", str(create_config.parent))
     monkeypatch.setenv("TEST_API_KEY_ENV", "tok")
 
     proxy_app = importlib.import_module("prompt_passage.proxy_app")
@@ -206,7 +202,7 @@ def test_chat_proxy_stream_upstream_error(
 
 
 def test_chat_proxy_stream_500(monkeypatch: pytest.MonkeyPatch, create_config: Path, httpx_mock: HTTPXMock) -> None:
-    monkeypatch.setenv("HOME", str(create_config.parent.parent))
+    monkeypatch.setenv("HOME", str(create_config.parent))
     monkeypatch.setenv("TEST_API_KEY_ENV", "tok")
 
     proxy_app = importlib.import_module("prompt_passage.proxy_app")


### PR DESCRIPTION
## Summary
- support optional `service` section in config with port and auth
- load service port in CLI when config is available
- add tests for service config parsing and defaults
- use helper for default config path
- update default config path to `~/.prompt-passage.yaml` with env override

## Testing
- `make check`
- `make test`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68579f69c7148332bbdfa878e680d0a1