### PR TITLE
Add Docker Hub publish workflow

### DIFF
--- a/.github/workflows/dockerhub-release.yml
+++ b/.github/workflows/dockerhub-release.yml
@@ -1,0 +1,32 @@
+name: Publish Docker image to Docker Hub
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/prompt-passage:${{ github.event.release.tag_name }},${{ secrets.DOCKERHUB_USERNAME }}/prompt-passage:latest


### PR DESCRIPTION
## Summary
- build Docker images and push to Docker Hub on release using docker/build-push-action

## Testing
- `make check`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6860d6be3934833286d70d53c93e6bbb