### PR TITLE
Add HTTPS support via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,18 @@ services:
       - AZURE_OPENAI_API_KEY  # include any env vars used in the config
 ```
 
+## HTTPS
+
+To serve the API over HTTPS, set `PROMPT_PASSAGE_CERTFILE` and optionally
+define `PROMPT_PASSAGE_KEYFILE` and `PROMPT_PASSAGE_CA_CERTS` for the
+private key and CA bundle:
+
+Example:
+
+```bash
+PROMPT_PASSAGE_CERTFILE=/path/server.crt \
+PROMPT_PASSAGE_KEYFILE=/path/server.key \
+PROMPT_PASSAGE_CA_CERTS=/path/ca.pem \
+python -m prompt_passage.cli
+```
+

--- a/src/prompt_passage/cli.py
+++ b/src/prompt_passage/cli.py
@@ -1,7 +1,8 @@
 import argparse
-import os
-import uvicorn
 import logging
+import os
+from typing import Any
+import uvicorn
 
 from .proxy_app import app
 from .config import load_config, default_config_path, ServiceCfg
@@ -32,7 +33,23 @@ def main() -> None:
         # Override port from command line argument if provided
         port = args.port
 
-    uvicorn.run(app, host=args.host, port=port, workers=args.workers)
+    certfile = os.getenv("PROMPT_PASSAGE_CERTFILE")
+    keyfile = os.getenv("PROMPT_PASSAGE_KEYFILE")
+    ca_certs = os.getenv("PROMPT_PASSAGE_CA_CERTS")
+
+    uvicorn_kwargs: dict[str, Any] = {
+        "host": args.host,
+        "port": port,
+        "workers": args.workers,
+    }
+    if certfile:
+        uvicorn_kwargs["ssl_certfile"] = certfile
+    if keyfile:
+        uvicorn_kwargs["ssl_keyfile"] = keyfile
+    if ca_certs:
+        uvicorn_kwargs["ssl_ca_certs"] = ca_certs
+
+    uvicorn.run(app, **uvicorn_kwargs)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,89 @@
+import importlib
+from pathlib import Path
+import yaml
+import pytest
+
+
+def _create_basic_config(path: Path) -> None:
+    cfg = {
+        "providers": {
+            "p": {
+                "endpoint": "https://example.com",
+                "model": "m",
+                "auth": {"type": "apikey", "key": "k"},
+            }
+        }
+    }
+    path.write_text(yaml.dump(cfg))
+
+
+def test_cli_https_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = tmp_path / ".prompt-passage.yaml"
+    _create_basic_config(cfg)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PROMPT_PASSAGE_CERTFILE", "/c.pem")
+    monkeypatch.setenv("PROMPT_PASSAGE_KEYFILE", "/k.pem")
+    monkeypatch.setenv("PROMPT_PASSAGE_CA_CERTS", "/ca.pem")
+
+    called = {}
+
+    def dummy_run(*args: object, **kwargs: object) -> None:
+        called.update(kwargs)
+
+    cli = importlib.import_module("prompt_passage.cli")
+    monkeypatch.setattr(cli.uvicorn, "run", dummy_run)
+    monkeypatch.setattr("sys.argv", ["prog"])  # clear pytest args
+
+    cli.main()
+
+    assert called.get("ssl_certfile") == "/c.pem"
+    assert called.get("ssl_keyfile") == "/k.pem"
+    assert called.get("ssl_ca_certs") == "/ca.pem"
+
+
+def test_cli_no_https(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = tmp_path / ".prompt-passage.yaml"
+    _create_basic_config(cfg)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("PROMPT_PASSAGE_CERTFILE", raising=False)
+    monkeypatch.delenv("PROMPT_PASSAGE_KEYFILE", raising=False)
+    monkeypatch.delenv("PROMPT_PASSAGE_CA_CERTS", raising=False)
+
+    called = {}
+
+    def dummy_run(*args: object, **kwargs: object) -> None:
+        called.update(kwargs)
+
+    cli = importlib.import_module("prompt_passage.cli")
+    monkeypatch.setattr(cli.uvicorn, "run", dummy_run)
+    monkeypatch.setattr("sys.argv", ["prog"])  # clear pytest args
+
+    cli.main()
+
+    assert "ssl_certfile" not in called
+    assert "ssl_keyfile" not in called
+    assert "ssl_ca_certs" not in called
+
+
+def test_cli_partial_https(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = tmp_path / ".prompt-passage.yaml"
+    _create_basic_config(cfg)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PROMPT_PASSAGE_CERTFILE", "/c.pem")
+    monkeypatch.delenv("PROMPT_PASSAGE_KEYFILE", raising=False)
+    monkeypatch.delenv("PROMPT_PASSAGE_CA_CERTS", raising=False)
+
+    called = {}
+
+    def dummy_run(*args: object, **kwargs: object) -> None:
+        called.update(kwargs)
+
+    cli = importlib.import_module("prompt_passage.cli")
+    monkeypatch.setattr(cli.uvicorn, "run", dummy_run)
+    monkeypatch.setattr("sys.argv", ["prog"])  # clear pytest args
+
+    cli.main()
+
+    assert called.get("ssl_certfile") == "/c.pem"
+    assert "ssl_keyfile" not in called
+    assert "ssl_ca_certs" not in called


### PR DESCRIPTION
## Summary
- allow running server with https if PROMPT_PASSAGE_CERTFILE, PROMPT_PASSAGE_KEYFILE and PROMPT_PASSAGE_CA_CERTS are set
- document the new env vars in README
- test CLI to ensure https options are passed to uvicorn

## Testing
- `make check`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6860d92455d483328759cd69b0917052